### PR TITLE
Require permissions for showing a column

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/form": "^4.2",
         "symfony/options-resolver": "^4.2",
         "symfony/property-access": "^4.2",
+        "symfony/security-core": "^4.2",
         "twig/twig": "^2 || ^3",
         "unlooped/helper": "^1.1.0",
         "unlooped/ts-resources": "^0.1.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "nesbot/carbon": "^2.21",
         "symfony/form": "^4.2",
         "symfony/options-resolver": "^4.2",
-        "symfony/property-access": "^4.2",
+        "symfony/property-access": "^4.3",
         "symfony/security-core": "^4.2",
         "twig/twig": "^2 || ^3",
         "unlooped/helper": "^1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0cc30186b73dbcfb76131736b475fe21",
+    "content-hash": "5e7e2cf5c07e69416350f5058750dc55",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -4683,6 +4683,91 @@
                 }
             ],
             "time": "2020-10-24T12:01:57+00:00"
+        },
+        {
+            "name": "symfony/security-core",
+            "version": "v4.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-core.git",
+                "reference": "fa1310e3fb2768f7f4cb6d3385faa24259a20604"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/fa1310e3fb2768f7f4cb6d3385faa24259a20604",
+                "reference": "fa1310e3fb2768f7f4cb6d3385faa24259a20604",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/event-dispatcher-contracts": "^1.1|^2",
+                "symfony/service-contracts": "^1.1.6|^2"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/ldap": "<4.4",
+                "symfony/security-guard": "<4.3"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "^4.3",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/ldap": "^4.4|^5.0",
+                "symfony/validator": "^3.4.31|^4.3.4|^5.0"
+            },
+            "suggest": {
+                "psr/container-implementation": "To instantiate the Security class",
+                "symfony/event-dispatcher": "",
+                "symfony/expression-language": "For using the expression voter",
+                "symfony/http-foundation": "",
+                "symfony/ldap": "For using LDAP integration",
+                "symfony/validator": "For using the user password constraint"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Core\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - Core Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-core/tree/v4.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-28T05:25:24+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e7e2cf5c07e69416350f5058750dc55",
+    "content-hash": "2e794e3afbf2350ca3f01b27444bb89f",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",

--- a/src/ColumnType/AbstractColumnType.php
+++ b/src/ColumnType/AbstractColumnType.php
@@ -5,19 +5,33 @@ namespace Unlooped\GridBundle\ColumnType;
 use Exception;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 abstract class AbstractColumnType implements ColumnTypeInterface
 {
     protected $template = '@UnloopedGrid/column_types/text.html.twig';
 
+    /**
+     * @var array
+     */
     protected $options;
-    protected $field;
-    protected $propertyAccessor;
-    protected $alias;
 
     /**
-     * Text constructor.
+     * @var string
      */
+    protected $field;
+
+    /**
+     * @var PropertyAccessorInterface
+     */
+    protected $propertyAccessor;
+
+    /**
+     * @var string|null
+     */
+    protected $alias;
+
     public function __construct(string $field, array $options = [], string $alias = null)
     {
         $resolver = new OptionsResolver();
@@ -33,12 +47,13 @@ abstract class AbstractColumnType implements ColumnTypeInterface
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'label'      => null,
-            'isSortable' => true,
-            'isMapped'   => true,
-            'attr'       => [],
-            'template'   => $this->template,
-            'meta'       => [],
+            'label'       => null,
+            'isSortable'  => true,
+            'isMapped'    => true,
+            'attr'        => [],
+            'template'    => $this->template,
+            'meta'        => [],
+            'permissions' => [],
         ]);
 
         $resolver->setAllowedTypes('label', ['null', 'string']);
@@ -46,6 +61,7 @@ abstract class AbstractColumnType implements ColumnTypeInterface
         $resolver->setAllowedTypes('attr', 'array');
         $resolver->setAllowedTypes('template', ['null', 'string']);
         $resolver->setAllowedTypes('meta', 'array');
+        $resolver->setAllowedTypes('permissions', 'array');
     }
 
     public function getValue($object)
@@ -74,6 +90,27 @@ abstract class AbstractColumnType implements ColumnTypeInterface
     public function getTemplate(): string
     {
         return $this->template;
+    }
+
+    public function isVisible(?UserInterface $user): bool
+    {
+        $permissions = $this->options['permissions'];
+
+        if (0 === \count($permissions)) {
+            return true;
+        }
+
+        if (null === $user) {
+            return false;
+        }
+
+        foreach ($user->getRoles() as $role) {
+            if (\in_array((string) $role, $permissions, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function getField(): string

--- a/src/ColumnType/AbstractColumnType.php
+++ b/src/ColumnType/AbstractColumnType.php
@@ -28,7 +28,7 @@ abstract class AbstractColumnType implements ColumnTypeInterface
     protected $propertyAccessor;
 
     /**
-     * @var string|null
+     * @var string
      */
     protected $alias;
 
@@ -41,7 +41,7 @@ abstract class AbstractColumnType implements ColumnTypeInterface
         $this->propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()->disableExceptionOnInvalidPropertyPath()->getPropertyAccessor();
 
         $this->field = $field;
-        $this->alias = $alias;
+        $this->alias = $alias ?? '';
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/ColumnType/ColumnTypeInterface.php
+++ b/src/ColumnType/ColumnTypeInterface.php
@@ -2,6 +2,11 @@
 
 namespace Unlooped\GridBundle\ColumnType;
 
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @method bool isVisible(?UserInterface $user)
+ */
 interface ColumnTypeInterface
 {
     public function getValue($object);

--- a/src/Helper/GridHelper.php
+++ b/src/Helper/GridHelper.php
@@ -24,17 +24,30 @@ class GridHelper
     /** @var int */
     private $defaultPage = 1;
 
-    /** @var AbstractColumnType[]|array */
-    private $columns     = [];
-    private $columnNames = [];
+    /** @var AbstractColumnType[] */
+    private array $columns = [];
+    private $columnNames   = [];
 
     /** @var Filter|null */
     private $filter;
+
+    /**
+     * @var FilterType[]
+     */
     private $filters = [];
     /** @var FilterType[] */
     private $defaultShowFilters = [];
+
+    /**
+     * @var array<string, string>
+     */
     private $filterNames        = [];
+
+    /**
+     * @var array<string, mixed>
+     */
     private $options;
+
     private $alias;
 
     public function __construct(QueryBuilder $queryBuilder, array $options = [], Filter $filter = null)
@@ -96,10 +109,12 @@ class GridHelper
     /**
      * @throws DuplicateColumnException
      * @throws TypeNotAColumnException
+     *
+     * @phpstan-param class-string<\Unlooped\GridBundle\ColumnType\ColumnTypeInterface> $type
      */
     public function addColumn(string $identifier, string $type = TextColumn::class, array $options = []): self
     {
-        if (!$this->options['allow_duplicate_columns'] && \in_array($identifier, $this->columnNames, true)) {
+        if (false === $this->options['allow_duplicate_columns'] && \in_array($identifier, $this->columnNames, true)) {
             throw new DuplicateColumnException('Column '.$identifier.' already exists in '.$this->name.' Grid Helper');
         }
 
@@ -118,6 +133,9 @@ class GridHelper
     /**
      * @throws DuplicateFilterException
      * @throws TypeNotAFilterException
+     *
+     * @phpstan-param class-string<FilterType> $type
+     * @phpstan-param array<string, mixed> $options
      */
     public function addFilter(string $identifier, ?string $type = FilterType::class, array $options = []): self
     {
@@ -129,7 +147,6 @@ class GridHelper
             throw new TypeNotAFilterException($type);
         }
 
-        /** @var FilterType $filterType */
         $filterType                 = new $type($identifier, $options);
         $key                        = $filterType->getOptions()['label'] ?? $identifier;
         $this->filterNames[$key]    = $identifier;
@@ -142,6 +159,9 @@ class GridHelper
         return $this;
     }
 
+    /**
+     * @return AbstractColumnType[]
+     */
     public function getColumns(): array
     {
         return $this->columns;
@@ -218,7 +238,7 @@ class GridHelper
     }
 
     /**
-     * @return array|FilterType[]
+     * @return FilterType[]
      */
     public function getFilters(): array
     {

--- a/src/Resources/views/column_headers.html.twig
+++ b/src/Resources/views/column_headers.html.twig
@@ -1,6 +1,6 @@
 {% block ug_list_header %}
     <tr>
-    {% for column in grid.columns %}
+    {% for column in grid.columns|filter(column => column.isVisible(app.user)) %}
         {% include '@UnloopedGrid/column_header.html.twig' with {'column': column, 'pagination': grid.pagination} %}
     {% endfor %}
     </tr>

--- a/src/Resources/views/list_row.html.twig
+++ b/src/Resources/views/list_row.html.twig
@@ -3,7 +3,7 @@
 
 {% block grid_list_row %}
     <tr>
-        {% for column in grid.columns %}
+        {% for column in grid.columns|filter(column => column.isVisible(app.user)) %}
             {% include column.template with {'type': column, 'data': data} %}
         {% endfor %}
     </tr>

--- a/tests/ColumnType/AbstractColumnTypeTest.php
+++ b/tests/ColumnType/AbstractColumnTypeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Unlooped\GridBundle\Tests\ColumnType;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Unlooped\GridBundle\Tests\Fixtures\TestColumnType;
+
+final class AbstractColumnTypeTest extends TestCase
+{
+    public function testIsVisible(): void
+    {
+        $user = $this->createMock(UserInterface::class);
+        $user->method('getRoles')->willReturn(['ADMIN', 'DEMO_ROLE']);
+
+        $columnType = new TestColumnType('demo', [
+            'permissions' => ['DEMO_ROLE'],
+        ]);
+        static::assertTrue($columnType->isVisible($user));
+    }
+
+    public function testIsAlwaysVisible(): void
+    {
+        $user = $this->createMock(UserInterface::class);
+        $user->expects(static::never())->method('getRoles');
+
+        $columnType = new TestColumnType('demo');
+        static::assertTrue($columnType->isVisible($user));
+    }
+
+    public function testIsNotVisibleForGuests(): void
+    {
+        $columnType = new TestColumnType('demo', [
+            'permissions' => ['DEMO_ROLE'],
+        ]);
+        static::assertFalse($columnType->isVisible(null));
+    }
+
+    public function testIsNotVisible(): void
+    {
+        $user = $this->createMock(UserInterface::class);
+        $user->method('getRoles')->willReturn([]);
+
+        $columnType = new TestColumnType('demo', [
+            'permissions' => ['DEMO_ROLE'],
+        ]);
+        static::assertFalse($columnType->isVisible($user));
+    }
+}

--- a/tests/Fixtures/TestColumnType.php
+++ b/tests/Fixtures/TestColumnType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Unlooped\GridBundle\Tests\Fixtures;
+
+use Unlooped\GridBundle\ColumnType\AbstractColumnType;
+
+class TestColumnType extends AbstractColumnType
+{
+}


### PR DESCRIPTION
# New Feature

Adds a new option called `permissions` to all `AbstractColumnTypes`. This option can contain multiple role names. Each column is checked when the template is rendered by twig.

```php
        $gh->addColumn('customerGroup.name', TextColumn::class, [
            'permissions' => ['ROLE_ADMIN', 'ROLE_MANAGER'],
        ]);
```

This logic should be moved to the PHP code, but requires some major refactoring in the `GridHelper`. This class should be refactored to used dependency injection instead of static instance creation.