### PR TITLE
Add new EntityFilter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "doctrine/orm": "^2.6",
         "knplabs/knp-paginator-bundle": "^5.0",
         "nesbot/carbon": "^2.21",
+        "symfony/doctrine-bridge": "^4.2",
         "symfony/form": "^4.2",
         "symfony/options-resolver": "^4.2",
         "symfony/property-access": "^4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e794e3afbf2350ca3f01b27444bb89f",
+    "content-hash": "c6859352a840ffb87a972fd7ce873ec3",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -530,16 +530,16 @@
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "2.1.2",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "f5153089993e1230f5d8acbd8e126014d5a63e17"
+                "reference": "c1b1fe95a6cce5e53a1454c46ae3500e53fadae1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/f5153089993e1230f5d8acbd8e126014d5a63e17",
-                "reference": "f5153089993e1230f5d8acbd8e126014d5a63e17",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/c1b1fe95a6cce5e53a1454c46ae3500e53fadae1",
+                "reference": "c1b1fe95a6cce5e53a1454c46ae3500e53fadae1",
                 "shasum": ""
             },
             "require": {
@@ -560,10 +560,10 @@
                 "twig/twig": "<1.34|>=2.0,<2.4"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "doctrine/orm": "^2.6",
                 "ocramius/proxy-manager": "^2.1",
-                "phpunit/phpunit": "^7.5",
+                "phpunit/phpunit": "^7.5 || ^9.3",
                 "symfony/phpunit-bridge": "^4.2",
                 "symfony/property-info": "^4.3.3|^5.0",
                 "symfony/proxy-manager-bridge": "^3.4|^4.3.3|^5.0",
@@ -571,7 +571,7 @@
                 "symfony/validator": "^3.4.30|^4.3.3|^5.0",
                 "symfony/web-profiler-bundle": "^3.4.30|^4.3.3|^5.0",
                 "symfony/yaml": "^3.4.30|^4.3.3|^5.0",
-                "twig/twig": "^1.34|^2.12"
+                "twig/twig": "^1.34|^2.12|^3.0"
             },
             "suggest": {
                 "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
@@ -580,7 +580,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
@@ -620,7 +620,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.1.2"
+                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.2.0"
             },
             "funding": [
                 {
@@ -636,7 +636,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-25T10:57:15+00:00"
+            "time": "2020-11-07T16:32:32+00:00"
         },
         {
             "name": "doctrine/event-manager",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -20,6 +20,11 @@
       <code>Select2EntityType</code>
     </UndefinedClass>
   </file>
+  <file src="src/Form/EntityType.php">
+    <InvalidCast occurrences="1">
+      <code>$entity</code>
+    </InvalidCast>
+  </file>
   <file src="src/Helper/RelationsHelper.php">
     <UndefinedInterfaceMethod occurrences="2">
       <code>getAssociationMapping</code>

--- a/src/FilterType/EntityFilterType.php
+++ b/src/FilterType/EntityFilterType.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Unlooped\GridBundle\FilterType;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Unlooped\GridBundle\Form\EntityType;
+
+final class EntityFilterType extends FilterType
+{
+    protected $template = '@UnloopedGrid/filter_types/entity.html.twig';
+
+    public function __construct(string $field, array $options = [])
+    {
+        parent::__construct($field, $options);
+    }
+
+    public static function getAvailableOperators(): array
+    {
+        return [
+            self::EXPR_EQ   => self::EXPR_EQ,
+            self::EXPR_NEQ  => self::EXPR_NEQ,
+        ];
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setDefaults([
+                'class'     => '',
+                'id_column' => 'id',
+            ])
+            ->setRequired('class')
+            ->setAllowedTypes('class', 'string')
+            ->setAllowedTypes('id_column', 'string')
+        ;
+    }
+
+    /**
+     * @param mixed|null $data
+     */
+    public function buildForm($builder, array $options = [], $data = null): void
+    {
+        $builder
+            ->remove('value')
+            ->add('value', EntityType::class, [
+                'required'            => false,
+                'translation_domain'  => 'unlooped_grid',
+                'class'               => $this->options['class'],
+                'id_column'           => $this->options['id_column'],
+            ])
+        ;
+    }
+}

--- a/src/Form/EntityType.php
+++ b/src/Form/EntityType.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Unlooped\GridBundle\Form;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
+final class EntityType extends AbstractType
+{
+    private ManagerRegistry $registry;
+    private PropertyAccessor $propertyAccessor;
+
+    public function __construct(ManagerRegistry $registry, PropertyAccessor $propertyAccessor)
+    {
+        $this->registry         = $registry;
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setDefaults([
+                'class'                     => '',
+                'choice_translation_domain' => false,
+                'id_column'                 => null,
+            ])
+            ->setNormalizer('choices', function (OptionsResolver $resolver): array {
+                $class    = $resolver['class'];
+                $idColumn = $resolver['id_column'];
+
+                $manager = $this->registry->getManagerForClass($class);
+
+                \assert($manager instanceof EntityManager);
+
+                $entities = $manager->createQueryBuilder()
+                    ->select('e')
+                    ->from($class, 'e')
+                    ->getQuery()->getResult();
+
+                return $this->buildChoices($entities, $idColumn);
+            })
+            ->setRequired('class')
+            ->setAllowedTypes('class', 'string')
+            ->setAllowedTypes('id_column', 'string')
+        ;
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'unlooped_entity';
+    }
+
+    /**
+     * @param object[] $entities
+     *
+     * @return array<string, int>
+     */
+    private function buildChoices(array $entities, string $idColumn): array
+    {
+        $choices = [];
+
+        foreach ($entities as $entity) {
+            $id = $this->propertyAccessor->getValue($entity, $idColumn);
+
+            $choices[(string) $entity] = $id;
+        }
+
+        return $choices;
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -15,3 +15,11 @@ services:
           - '@router.default'
           -
           -
+
+    Unlooped\GridBundle\Form\EntityType:
+        public: true
+        tags:
+            - 'form.type'
+        arguments:
+            - '@doctrine'
+            - '@property_accessor'

--- a/src/Resources/views/filter_types/entity.html.twig
+++ b/src/Resources/views/filter_types/entity.html.twig
@@ -1,0 +1,3 @@
+<div class="input-group filter-value-container">
+    {{ form_widget(data.value) }}
+</div>

--- a/tests/Fixtures/TestEntity.php
+++ b/tests/Fixtures/TestEntity.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Unlooped\GridBundle\Tests\Fixtures;
+
+class TestEntity
+{
+    private int $id;
+
+    private string $name;
+
+    /**
+     * TestEntity constructor.
+     */
+    public function __construct(int $id, string $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+
+    public function __toString()
+    {
+        return $this->getName();
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Form/BaseTypeTest.php
+++ b/tests/Form/BaseTypeTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unlooped\GridBundle\Tests\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+abstract class BaseTypeTest extends TypeTestCase
+{
+    public function testPassDisabledAsOption(): void
+    {
+        $form = $this->create(null, ['disabled' => true]);
+
+        static::assertTrue($form->isDisabled());
+    }
+
+    public function testPassIdAndNameToView(): void
+    {
+        $view = $this->createNamed('name')
+            ->createView()
+        ;
+
+        static::assertSame('name', $view->vars['id']);
+        static::assertSame('name', $view->vars['name']);
+        static::assertSame('name', $view->vars['full_name']);
+    }
+
+    public function testStripLeadingUnderscoresAndDigitsFromId(): void
+    {
+        $view = $this->createNamed('_09name')
+            ->createView()
+        ;
+
+        static::assertSame('name', $view->vars['id']);
+        static::assertSame('_09name', $view->vars['name']);
+        static::assertSame('_09name', $view->vars['full_name']);
+    }
+
+    public function testPassIdAndNameToViewWithParent(): void
+    {
+        $view = $this->createBuilder()
+            ->getForm()
+            ->createView()
+        ;
+
+        static::assertSame('parent_child', $view['child']->vars['id']);
+        static::assertSame('child', $view['child']->vars['name']);
+        static::assertSame('parent[child]', $view['child']->vars['full_name']);
+    }
+
+    public function testPassIdAndNameToViewWithGrandParent(): void
+    {
+        $builder = $this->factory->createNamedBuilder('parent', FormType::class)
+            ->add('child', FormType::class)
+        ;
+        $builder->get('child')->add('grand_child', $this->getTestedType());
+        $view = $builder->getForm()->createView();
+
+        static::assertSame('parent_child_grand_child', $view['child']['grand_child']->vars['id']);
+        static::assertSame('grand_child', $view['child']['grand_child']->vars['name']);
+        static::assertSame('parent[child][grand_child]', $view['child']['grand_child']->vars['full_name']);
+    }
+
+    public function testPassTranslationDomainToView(): void
+    {
+        $view = $this->create(null, [
+            'translation_domain' => 'domain',
+        ])
+            ->createView()
+        ;
+
+        static::assertSame('domain', $view->vars['translation_domain']);
+    }
+
+    public function testInheritTranslationDomainFromParent(): void
+    {
+        $view = $this->createBuilder([
+            'translation_domain' => 'domain',
+        ])
+            ->getForm()
+            ->createView()
+        ;
+
+        static::assertSame('domain', $view['child']->vars['translation_domain']);
+    }
+
+    public function testPreferOwnTranslationDomain(): void
+    {
+        $view = $this->createBuilder([
+            'translation_domain' => 'parent_domain',
+        ], [
+            'translation_domain' => 'domain',
+        ])
+            ->getForm()
+            ->createView()
+        ;
+
+        static::assertSame('domain', $view['child']->vars['translation_domain']);
+    }
+
+    public function testDefaultTranslationDomain(): void
+    {
+        $view = $this->createBuilder()
+            ->getForm()
+            ->createView()
+        ;
+
+        static::assertNull($view['child']->vars['translation_domain']);
+    }
+
+    public function testPassLabelToView(): void
+    {
+        $view = $this->createNamed('__test___field', null, ['label' => 'My label'])
+            ->createView()
+        ;
+
+        static::assertSame('My label', $view->vars['label']);
+    }
+
+    public function testPassMultipartFalseToView(): void
+    {
+        $view = $this->create()
+            ->createView()
+        ;
+
+        static::assertFalse($view->vars['multipart']);
+    }
+
+    /**
+     * @param mixed|null $expected
+     * @param mixed|null $norm
+     * @param mixed|null $view
+     */
+    public function testSubmitNull($expected = null, $norm = null, $view = '0'): void
+    {
+        $form = $this->create();
+        $form->submit(null);
+
+        static::assertSame($expected, $form->getData());
+        static::assertSame($norm, $form->getNormData());
+        static::assertSame($view, $form->getViewData());
+    }
+
+    /**
+     * @param mixed|null $data
+     */
+    protected function create($data = null, array $options = []): FormInterface
+    {
+        return $this->factory->create($this->getTestedType(), $data, $options);
+    }
+
+    /**
+     * @param mixed|null $data
+     */
+    protected function createNamed(string $name, $data = null, array $options = []): FormInterface
+    {
+        return $this->factory->createNamed($name, $this->getTestedType(), $data, $options);
+    }
+
+    protected function createBuilder(array $parentOptions = [], array $childOptions = []): FormBuilderInterface
+    {
+        return $this->factory
+            ->createNamedBuilder('parent', FormType::class, null, $parentOptions)
+            ->add('child', $this->getTestedType(), $childOptions)
+        ;
+    }
+
+    abstract protected function getTestedType(): string;
+}

--- a/tests/Form/EntityTypeTest.php
+++ b/tests/Form/EntityTypeTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Unlooped\GridBundle\Tests\Form;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Unlooped\GridBundle\Form\EntityType;
+use Unlooped\GridBundle\Tests\Fixtures\TestEntity;
+
+final class EntityTypeTest extends BaseTypeTest
+{
+    private ManagerRegistry $registry;
+    private EntityManager $entityManager;
+    private PropertyAccessor $propertyAccessor;
+
+    protected function setUp(): void
+    {
+        $query        = $this->createMock(AbstractQuery::class);
+        $query->method('getResult')->willReturn([
+            new TestEntity(1, 'One'),
+            new TestEntity(2, 'Two'),
+        ]);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('getQuery')->willReturn($query);
+        $this->entityManager = $this->createMock(EntityManager::class);
+        $this->entityManager->method('createQueryBuilder')
+            ->willReturn($queryBuilder)
+        ;
+
+        $this->registry = $this->createMock(ManagerRegistry::class);
+        $this->registry->method('getManagerForClass')->with(TestEntity::class)
+            ->willReturn($this->entityManager)
+        ;
+        $this->propertyAccessor = $this->createMock(PropertyAccessor::class);
+
+        parent::setUp();
+    }
+
+    public function testPassIdAndNameToViewWithGrandParent(): void
+    {
+        $builder = $this->factory->createNamedBuilder('parent', FormType::class)
+            ->add('child', FormType::class)
+        ;
+        $builder->get('child')->add('grand_child', $this->getTestedType(), [
+            'class'      => TestEntity::class,
+            'id_column'  => 'id',
+        ]);
+        $view = $builder->getForm()->createView();
+
+        static::assertSame('parent_child_grand_child', $view['child']['grand_child']->vars['id']);
+        static::assertSame('grand_child', $view['child']['grand_child']->vars['name']);
+        static::assertSame('parent[child][grand_child]', $view['child']['grand_child']->vars['full_name']);
+    }
+
+    protected function create($data = null, array $options = []): FormInterface
+    {
+        $options = array_merge([
+            'class'      => TestEntity::class,
+            'id_column'  => 'id',
+        ], $options);
+
+        return $this->factory->create($this->getTestedType(), $data, $options);
+    }
+
+    protected function createNamed(string $name, $data = null, array $options = []): FormInterface
+    {
+        $options = array_merge([
+            'class'      => TestEntity::class,
+            'id_column'  => 'id',
+        ], $options);
+
+        return $this->factory->createNamed($name, $this->getTestedType(), $data, $options);
+    }
+
+    protected function createBuilder(array $parentOptions = [], array $childOptions = []): FormBuilderInterface
+    {
+        $childOptions = array_merge([
+            'class'      => TestEntity::class,
+            'id_column'  => 'id',
+        ], $childOptions);
+
+        return $this->factory
+            ->createNamedBuilder('parent', FormType::class, null, $parentOptions)
+            ->add('child', $this->getTestedType(), $childOptions)
+        ;
+    }
+
+    protected function getTestedType(): string
+    {
+        return EntityType::class;
+    }
+
+    protected function getTypes(): array
+    {
+        return [
+            new EntityType($this->registry, $this->propertyAccessor),
+        ];
+    }
+}


### PR DESCRIPTION
# New Feature

Adds a new reusable filter that can be used to filter the grid by an entity relation. 

## Example 

```php
        $gh->addFilter('customerGroup', EntityFilterType::class, [
            'class'      => CustomerGroup::class,
            // 'id_column' => 'custom_id',
        ]);

```