### PR TITLE
Add GlobalSearchFilterType

### DIFF
--- a/src/ColumnType/ActionsColumn.php
+++ b/src/ColumnType/ActionsColumn.php
@@ -30,5 +30,4 @@ class ActionsColumn extends AbstractColumnType
             return null;
         }
     }
-
 }

--- a/src/ColumnType/BadgeColumn.php
+++ b/src/ColumnType/BadgeColumn.php
@@ -4,8 +4,8 @@ namespace Unlooped\GridBundle\ColumnType;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class BadgeColumn extends AbstractColumnType {
-
+class BadgeColumn extends AbstractColumnType
+{
     protected $template = '@UnloopedGrid/column_types/badge.html.twig';
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -15,6 +15,4 @@ class BadgeColumn extends AbstractColumnType {
         $resolver->setDefaults(['classPrefix' => null]);
         $resolver->setAllowedTypes('classPrefix', ['null', 'string']);
     }
-
-
 }

--- a/src/ColumnType/CurrencyColumn.php
+++ b/src/ColumnType/CurrencyColumn.php
@@ -5,8 +5,8 @@ namespace Unlooped\GridBundle\ColumnType;
 use Symfony\Component\Intl\Currencies;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class CurrencyColumn extends AbstractColumnType {
-
+class CurrencyColumn extends AbstractColumnType
+{
     protected $template = '@UnloopedGrid/column_types/currency.html.twig';
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -14,12 +14,10 @@ class CurrencyColumn extends AbstractColumnType {
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-            'currency' => 'EUR'
+            'currency' => 'EUR',
         ]);
 
         $resolver->setAllowedTypes('currency', ['string']);
         $resolver->setAllowedValues('currency', Currencies::getCurrencyCodes());
     }
-
-
 }

--- a/src/ColumnType/NumberColumn.php
+++ b/src/ColumnType/NumberColumn.php
@@ -2,8 +2,7 @@
 
 namespace Unlooped\GridBundle\ColumnType;
 
-class NumberColumn extends AbstractColumnType {
-
+class NumberColumn extends AbstractColumnType
+{
     protected $template = '@UnloopedGrid/column_types/number.html.twig';
-
 }

--- a/src/ColumnType/PercentColumn.php
+++ b/src/ColumnType/PercentColumn.php
@@ -2,8 +2,7 @@
 
 namespace Unlooped\GridBundle\ColumnType;
 
-class PercentColumn extends AbstractColumnType {
-
+class PercentColumn extends AbstractColumnType
+{
     protected $template = '@UnloopedGrid/column_types/percent.html.twig';
-
 }

--- a/src/FilterType/GlobalSearchFilterType.php
+++ b/src/FilterType/GlobalSearchFilterType.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Unlooped\GridBundle\FilterType;
+
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Unlooped\GridBundle\Entity\FilterRow;
+
+class GlobalSearchFilterType extends AbstractFilterType
+{
+    /**
+     * @var string[]
+     */
+    private array $entityJoinAliases = [];
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setRequired('fields');
+        $resolver->setAllowedTypes('fields', 'string[]');
+    }
+
+    public function handleFilter(QueryBuilder $qb, FilterRow $filterRow, array $options = []): void
+    {
+        $searchfields = $options['fields'];
+        $text         = $filterRow->getValue();
+
+        $orX = $qb->expr()->orX();
+
+        foreach ($searchfields as $searchfield) {
+            $fields = explode('.', $searchfield);
+            $field  = end($fields);
+
+            $mappings    = [];
+            $fieldsCount = \count($fields);
+            for ($i = 0; $i < $fieldsCount - 1; ++$i) {
+                $mappings[] = ['fieldName' => $fields[$i]];
+            }
+            $alias = $this->entityJoin($qb, $mappings);
+
+            $orX->add($qb->expr()->like(sprintf('%s.%s', $alias, $field), $qb->expr()->literal('%'.$text.'%')));
+        }
+
+        $qb->andWhere($orX);
+    }
+
+    protected static function getAvailableOperators(): array
+    {
+        return [
+            self::EXPR_EQ => self::EXPR_EQ,
+        ];
+    }
+
+    /**
+     * @param array<mixed> $associationMappings
+     *
+     * @phpstan-param array<array{fieldName: string}> $associationMappings
+     */
+    private function entityJoin(QueryBuilder $qb, array $associationMappings): string
+    {
+        $alias = current($qb->getRootAliases());
+
+        $newAlias = 's';
+
+        $joinedEntities = $qb->getDQLPart('join');
+
+        foreach ($associationMappings as $associationMapping) {
+            // Do not add left join to already joined entities with custom query
+            foreach ($joinedEntities as $joinExprList) {
+                foreach ($joinExprList as $joinExpr) {
+                    $newAliasTmp = $joinExpr->getAlias();
+
+                    if (sprintf('%s.%s', $alias, $associationMapping['fieldName']) === $joinExpr->getJoin()) {
+                        $this->entityJoinAliases[] = $newAliasTmp;
+                        $alias                     = $newAliasTmp;
+
+                        continue 3;
+                    }
+                }
+            }
+
+            $newAlias .= '_'.$associationMapping['fieldName'];
+            if (!\in_array($newAlias, $this->entityJoinAliases, true)) {
+                $this->entityJoinAliases[] = $newAlias;
+                $qb->leftJoin(sprintf('%s.%s', $alias, $associationMapping['fieldName']), $newAlias);
+            }
+
+            $alias = $newAlias;
+        }
+
+        return $alias;
+    }
+}


### PR DESCRIPTION
Example

```php

class DemoGrid implements Grid
{
    public function configure(GridHelper $grid): void
    {
        // ...

        $grid->addFilter('global', GlobalSearchFilterType::class, [
            'fields' => ['firstName', 'lastName', 'customerGroup.name']
        ]);
    }

    // ...
}


```