### PR TITLE
Add query_builder option to all filters

### DIFF
--- a/src/Action/AutocompleteAction.php
+++ b/src/Action/AutocompleteAction.php
@@ -10,6 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Unlooped\GridBundle\Entity\FilterRow;
 use Unlooped\GridBundle\Filter\Filter;
 use Unlooped\GridBundle\FilterType\AutocompleteFilterType;
 use Unlooped\GridBundle\Grid\Grid;
@@ -140,14 +141,19 @@ class AutocompleteAction
 
     private function createQueryBuilder(EntityRepository $repository, string $field, string $term, ?callable $queryBuiler): QueryBuilder
     {
-        if (null !== $queryBuiler) {
-            return $queryBuiler($repository, $term);
-        }
-
-        return $repository
-            ->createQueryBuilder('e')
+        $qb = $repository->createQueryBuilder('e')
             ->where(sprintf('e.%s LIKE :term', $field))
             ->setParameter('term', '%'.$term.'%')
         ;
+
+        if (null !== $queryBuiler) {
+            $filterRow = new FilterRow();
+            $filterRow->setField($field);
+            $filterRow->setValue($term);
+
+            return $queryBuiler($qb, $filterRow);
+        }
+
+        return $qb;
     }
 }

--- a/src/FilterType/AbstractFilterType.php
+++ b/src/FilterType/AbstractFilterType.php
@@ -125,6 +125,7 @@ abstract class AbstractFilterType implements FilterType
             'attr'          => [],
             'widget'        => 'text',
             'operators'     => static::getAvailableOperators(),
+            'query_builder' => null,
         ]);
 
         $resolver->setAllowedTypes('show_filter', ['boolean']);
@@ -134,6 +135,7 @@ abstract class AbstractFilterType implements FilterType
         $resolver->setAllowedTypes('widget', 'string');
         $resolver->setAllowedTypes('operators', 'array');
         $resolver->setAllowedTypes('default_data', ['null', DefaultFilterDataStruct::class]);
+        $resolver->setAllowedTypes('query_builder', ['null', 'callable']);
 
         $resolver->setAllowedValues('widget', ['text']);
     }
@@ -183,6 +185,11 @@ abstract class AbstractFilterType implements FilterType
             $qb->setParameter('value_'.$suffix, $value);
         } elseif (!$this->hasExpressionValue($filterRow)) {
             $qb->andWhere($qb->expr()->{$op}($alias));
+        }
+
+        $queryBuilder = $options['query_builder'];
+        if (null !== $queryBuilder) {
+            $queryBuilder($qb, $filterRow);
         }
     }
 

--- a/src/FilterType/AutocompleteFilterType.php
+++ b/src/FilterType/AutocompleteFilterType.php
@@ -30,7 +30,6 @@ class AutocompleteFilterType extends AbstractFilterType
             'multiple'             => false,
             'entity'               => '',
             'entity_primary_key'   => 'id',
-            'query_builder'        => null,
             'grid'                 => null,
             'grid_field'           => null,
             'text_property'        => null,
@@ -49,8 +48,6 @@ class AutocompleteFilterType extends AbstractFilterType
         $resolver->setAllowedTypes('minimum_input_length', 'int');
         $resolver->setAllowedTypes('text_property', ['string', 'null']);
         $resolver->setAllowedTypes('multiple', 'boolean');
-
-        $resolver->setAllowedTypes('query_builder', ['null', 'callable']);
     }
 
     public function buildForm($builder, array $options = [], $data = null): void

--- a/src/FilterType/DateFilterType.php
+++ b/src/FilterType/DateFilterType.php
@@ -177,6 +177,11 @@ class DateFilterType extends AbstractFilterType
         } elseif (!$this->hasExpressionValue($filterRow)) {
             $qb->andWhere($qb->expr()->{$op}($field));
         }
+
+        $queryBuilder = $options['query_builder'];
+        if (null !== $queryBuilder) {
+            $queryBuilder($qb, $filterRow);
+        }
     }
 
     public function replaceVarsInValue(string $value, array $options = []): string

--- a/src/FilterType/DateRangeFilterType.php
+++ b/src/FilterType/DateRangeFilterType.php
@@ -79,6 +79,11 @@ class DateRangeFilterType extends DateFilterType
             $qb->andWhere($qb->expr()->lt($field, ':value_end_'.$suffix));
             $qb->setParameter('value_end_'.$suffix, $endDate->timezone($options['target_timezone']));
         }
+
+        $queryBuilder = $options['query_builder'];
+        if (null !== $queryBuilder) {
+            $queryBuilder($qb, $filterRow);
+        }
     }
 
     public function buildForm($builder, array $options = [], $data = null): void

--- a/src/FilterType/NumberRangeFilterType.php
+++ b/src/FilterType/NumberRangeFilterType.php
@@ -26,6 +26,11 @@ class NumberRangeFilterType extends AbstractFilterType
             $qb->andWhere($qb->expr()->lte($field, ':value_end_'.$suffix));
             $qb->setParameter('value_end_'.$suffix, $toValue);
         }
+
+        $queryBuilder = $options['query_builder'];
+        if (null !== $queryBuilder) {
+            $queryBuilder($qb, $filterRow);
+        }
     }
 
     public function buildForm($builder, array $options = [], $data = null): void


### PR DESCRIPTION
Allow extending the query builder for all filters

Example
```php
class DemoGrid implements Grid
{
    public function configure(GridHelper $grid): void
    {
        // ...

        $grid->addFilter('createdAt', DateRangeFilterType::class, [
            'view_timezone' => 'UTC',
            'show_filter' => true,
            'label' => 'Created At',
            'default_data' => DateRangeFilterType::createDefaultDataForRangeVariables('ONE_WEEK_AGO', 'TODAY'),
            'query_builder' => static function(QueryBuilder $qb, FilterRow $row): QueryBuilder {
                return $qb
                    ->andWhere(sprintf('%s.firstName = :value', $qb->getRootAlias()))
                    ->setParameter('value', 'Kelli')
                ;
            }
        ]);
    }

    // ...
}
```

There's a BC break when defining the `query_builder` option for the `AutocompleteFilterType`:
```diff
        $grid->addFilter('customerGroup', AutocompleteFilterType::class, [
            'multiple' => true,
            'show_filter'          => true,
            'label'                => 'Group Autocomplete',
            'grid'                 => 'demo_grid',
            'entity'               => CustomerGroup::class,
            'minimum_input_length' => 1,
            'text_property'        => 'name',
-            'query_builder' => static function(EntityRepository $qb, string $term): QueryBuilder {
-                return $qb
-                    ->createQueryBuilder('e')
-                    ->where('e.name LIKE :term')
-                    ->setParameter('term', '%'.$term.'%')
-                    ->andWhere('e.id = 1')
+            'query_builder' => static function(QueryBuilder $qb, FilterRow $row): QueryBuilder {
+                return $qb
+                    ->where('e.name LIKE :term')
+                    ->setParameter('term', '%'.$row->getValue().'%')
+                    ->andWhere('e.id = 1')
                ;
            }

```