### PR TITLE
Add AutocompleteTextFilterType

### DIFF
--- a/src/DependencyInjection/UnloopedGridExtension.php
+++ b/src/DependencyInjection/UnloopedGridExtension.php
@@ -5,12 +5,13 @@ namespace Unlooped\GridBundle\DependencyInjection;
 use Exception;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 use Unlooped\GridBundle\Service\GridService;
 
-class UnloopedGridExtension extends ConfigurableExtension
+class UnloopedGridExtension extends ConfigurableExtension implements PrependExtensionInterface
 {
     /**
      * Loads a specific configuration.
@@ -30,5 +31,14 @@ class UnloopedGridExtension extends ConfigurableExtension
             ->replaceArgument(9, $config['save_filter'])
             ->replaceArgument(10, $config['use_route_in_filter_reference'])
         ;
+    }
+
+    public function prepend(ContainerBuilder $container)
+    {
+        if ($container->hasExtension('twig')) {
+            $container->prependExtensionConfig('twig', [
+                'form_themes' => ['@UnloopedGrid/Form/fields.html.twig'],
+            ]);
+        }
     }
 }

--- a/src/FilterType/AutocompleteFilterType.php
+++ b/src/FilterType/AutocompleteFilterType.php
@@ -5,6 +5,7 @@ namespace Unlooped\GridBundle\FilterType;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Form\FormEvent;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Tetranz\Select2EntityBundle\Form\Type\Select2EntityType;
@@ -28,21 +29,21 @@ class AutocompleteFilterType extends AbstractFilterType
         $resolver->setDefaults([
             'route'                => 'unlooped_grid_autocomplete',
             'multiple'             => false,
-            'entity'               => '',
             'entity_primary_key'   => 'id',
-            'grid'                 => null,
-            'grid_field'           => null,
-            'text_property'        => null,
             'minimum_input_length' => 2,
         ]);
+
+        $resolver->setDefault('text_property', static function (Options $options, $previousValue) {
+            return $options['grid_field'] ?? $previousValue;
+        });
 
         $resolver->setRequired('entity');
         $resolver->setRequired('grid');
         $resolver->setRequired('grid_field');
-        $resolver->setRequired('minimum_input_length');
 
         $resolver->setAllowedTypes('route', 'string');
         $resolver->setAllowedTypes('entity', 'string');
+        $resolver->setAllowedTypes('entity_primary_key', 'string');
         $resolver->setAllowedTypes('grid', ['string', 'null']);
         $resolver->setAllowedTypes('grid_field', ['string', 'null']);
         $resolver->setAllowedTypes('minimum_input_length', 'int');

--- a/src/FilterType/AutocompleteTextFilterType.php
+++ b/src/FilterType/AutocompleteTextFilterType.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Unlooped\GridBundle\FilterType;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\RouterInterface;
+
+class AutocompleteTextFilterType extends TextFilterType
+{
+    private RouterInterface $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults([
+            'route'                => 'unlooped_grid_autocomplete',
+            'query_builder'        => null,
+            'minimum_input_length' => 2,
+        ]);
+
+        $resolver->setDefault('text_property', static function (Options $options, $previousValue) {
+            return $options['grid_field'] ?? $previousValue;
+        });
+
+        $resolver->setRequired('entity');
+        $resolver->setRequired('grid');
+        $resolver->setRequired('grid_field');
+
+        $resolver->setAllowedTypes('route', 'string');
+        $resolver->setAllowedTypes('entity', 'string');
+        $resolver->setAllowedTypes('grid', ['string', 'null']);
+        $resolver->setAllowedTypes('grid_field', ['string', 'null']);
+        $resolver->setAllowedTypes('minimum_input_length', 'int');
+        $resolver->setAllowedTypes('text_property', ['string', 'null']);
+    }
+
+    public function buildForm($builder, array $options = [], $data = null): void
+    {
+        $builder
+            ->add('value', HiddenType::class, [
+                'attr' => [
+                    'data-ajax--url' => $this->router->generate($options['route'], [
+                        'grid'       => $options['grid'],
+                        'field'      => $options['grid_field'],
+                        'page_limit' => 10,
+                    ]),
+                    'data-ajax--cache'          => true,
+                    'data-ajax--cache-timeout'  => 60000,
+                    'data-ajax--delay'          => 250,
+                    'data-ajax--data-type'      => 'json',
+                    'data-language'             => 'de',
+                    'data-theme'                => 'default',
+                    'data-minimum-input-length' => $options['minimum_input_length'],
+                    'data-placeholder'          => '',
+                    'data-page-limit'           => 10,
+                    'data-scroll'               => 'false',
+                    'data-autostart'            => 'true',
+                    'data-allow-clear'          => 'true',
+                    'class'                     => 'select2text form-control',
+                ],
+                'block_prefix' => 'gridbundle_autocomplete',
+            ])
+        ;
+    }
+}

--- a/src/Helper/GridHelper.php
+++ b/src/Helper/GridHelper.php
@@ -19,6 +19,7 @@ use Unlooped\GridBundle\Filter\Registry\FilterRegistry;
 use Unlooped\GridBundle\FilterType\AutocompleteFilterType;
 use Unlooped\GridBundle\FilterType\DefaultFilterType;
 use Unlooped\GridBundle\FilterType\FilterType;
+use Unlooped\GridBundle\FilterType\AutocompleteTextFilterType;
 use Unlooped\GridBundle\Struct\DefaultFilterDataStruct;
 
 class GridHelper
@@ -180,7 +181,7 @@ class GridHelper
             throw new TypeNotAFilterException($type);
         }
 
-        if (AutocompleteFilterType::class === $type) {
+        if (AutocompleteFilterType::class === $type || AutocompleteTextFilterType::class === $type) {
             $options['grid_field'] = $identifier;
         }
 

--- a/src/Resources/assets/ts/FilterType/AutocompleteTextFilterType.ts
+++ b/src/Resources/assets/ts/FilterType/AutocompleteTextFilterType.ts
@@ -1,0 +1,11 @@
+import {FilterType} from "./FilterType";
+
+export class AutocompleteTextFilterType extends FilterType {
+
+    public updateValueInput(row: Element, fieldName: string, config: any) {
+        super.updateValueInput(row, fieldName, config);
+
+        // @ts-ignore
+        jQuery('.select2text[data-autostart="true"]').select2entity();
+    }
+}

--- a/src/Resources/assets/ts/Manager/FilterManager.ts
+++ b/src/Resources/assets/ts/Manager/FilterManager.ts
@@ -2,6 +2,7 @@ import {FilterType} from "../FilterType/FilterType";
 import {DateFilterType} from "../FilterType/DateFilterType";
 import {DateRangeFilterType} from "../FilterType/DateRangeFilterType";
 import {AutocompleteFilterType} from "../FilterType/AutocompleteFilterType";
+import {AutocompleteTextFilterType} from "../FilterType/AutocompleteTextFilterType";
 
 export class FilterManager {
 
@@ -14,6 +15,7 @@ export class FilterManager {
         'Unlooped\\GridBundle\\FilterType\\DateFilterType': new DateFilterType(),
         'Unlooped\\GridBundle\\FilterType\\DateRangeFilterType': new DateRangeFilterType(),
         'Unlooped\\GridBundle\\FilterType\\AutocompleteFilterType': new AutocompleteFilterType(),
+        'Unlooped\\GridBundle\\FilterType\\AutocompleteTextFilterType': new AutocompleteTextFilterType(),
     };
 
     constructor(filterForm: Element, options = []) {

--- a/src/Resources/config/filter.php
+++ b/src/Resources/config/filter.php
@@ -12,6 +12,7 @@ use Unlooped\GridBundle\FilterType\DateRangeFilterType;
 use Unlooped\GridBundle\FilterType\EntityFilterType;
 use Unlooped\GridBundle\FilterType\FilterType;
 use Unlooped\GridBundle\FilterType\NumberRangeFilterType;
+use Unlooped\GridBundle\FilterType\AutocompleteTextFilterType;
 use Unlooped\GridBundle\FilterType\TextFilterType;
 
 return static function (ContainerConfigurator $container): void {
@@ -36,5 +37,9 @@ return static function (ContainerConfigurator $container): void {
         ->set(EntityFilterType::class)
         ->set(NumberRangeFilterType::class)
         ->set(TextFilterType::class)
+        ->set(AutocompleteTextFilterType::class)
+            ->args([
+                ref('router'),
+            ])
     ;
 };

--- a/src/Resources/views/Form/fields.html.twig
+++ b/src/Resources/views/Form/fields.html.twig
@@ -1,0 +1,9 @@
+{% block gridbundle_autocomplete_widget %}
+    {% apply spaceless %}
+        <select {{ block('widget_attributes') }}>
+            {% if value  %}
+                <option value="{{ value }}" selected="selected">{{ value }}</option>
+            {% endif %}
+        </select>
+    {% endapply %}
+{% endblock %}


### PR DESCRIPTION
Example
```php
class DemoGrid implements Grid
{
    public function configure(GridHelper $grid): void
    {
        // ...

        $grid->addFilter('firstName', AutocompleteTextFilterType::class, [
            'show_filter'          => true,
            'label'                => 'Firstname Autocomplete',
            'grid'                 => 'demo_grid',
            'entity'               => Customer::class,
            'minimum_input_length' => 1,
        ]);
    }

    // ...
}
```

